### PR TITLE
Add Ansible role

### DIFF
--- a/contrib/ansible-role/README.md
+++ b/contrib/ansible-role/README.md
@@ -1,0 +1,26 @@
+# matrix-registration-bot Ansible role
+
+Written for Debian 11
+(does not work on Debian 10 with Python 3.7,
+because the [simplematrixbotlib](https://pypi.org/project/simplematrixbotlib/)
+dependency is only available for newer Python versions).
+
+Installs the virtual environment in `/opt/venvs/matrix-registration-bot`
+next to the virtual environment created by the official Matrix Synapse Debian package.
+
+
+## Usage
+
+Copy this role to your desired Ansible roles directory, name and modify it as you see fit
+and configure the variables below for your groups/hosts.
+Use the Ansible Vault to store secrets.
+
+
+### Variables
+
+* `matrix_registration_bot_system_user` the username of the system user to run the bot as (will be created)
+* `matrix_client_api_endpoint` the Matrix client API base url to access (to access the `/_matrix/client/` endpoints)
+* `matrix_registration_bot_username` the Matrix username to identify as
+* `matrix_registration_bot_token` the Matrix bot user's authentication token
+* `synapse_api_endpoint` the Synapse server API base url (to access the `/_synapse/admin/` endpoints)
+* `synapse_admin_token` the access token of an administrative user

--- a/contrib/ansible-role/meta/main.yml
+++ b/contrib/ansible-role/meta/main.yml
@@ -1,0 +1,3 @@
+---
+name: Install Matrix registration bot
+become: yes

--- a/contrib/ansible-role/tasks/main.yml
+++ b/contrib/ansible-role/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+- name: Update/install pip, virtualenv, setuptools and others
+  ansible.builtin.apt:
+    pkg:
+      - python3
+      - python3-pip
+      - python3-setuptools
+      - python3-virtualenv
+      - python3-cryptography
+      - python3-yaml
+    update_cache: yes
+    state: present
+- name: Update/install matrix-registration-bot
+  ansible.builtin.pip:
+    name:
+      - simplematrixbotlib>=2.6.0,<3.0.0
+      - aiohttp[speedups]
+      - matrix-registration-bot
+    state: latest
+    virtualenv: /opt/venvs/matrix-registration-bot
+    virtualenv_site_packages: yes
+- name: Ensure system user exists
+  ansible.builtin.user:
+    name: '{{ matrix_registration_bot_system_user }}'
+    create_home: no
+    home: /opt/venvs/matrix-registration-bot
+    state: present
+    system: yes
+- name: Ensure configuration directory exists
+  ansible.builtin.file:
+    path: /etc/matrix-registration-bot/
+    owner: '{{ matrix_registration_bot_system_user }}'
+    group: '{{ matrix_registration_bot_system_user }}'
+    mode: 0755
+    state: directory
+- name: Update configuration file
+  ansible.builtin.template:
+    src: config.yml.j2
+    dest: /etc/matrix-registration-bot/config.yml
+    owner: '{{ matrix_registration_bot_system_user }}'
+    group: '{{ matrix_registration_bot_system_user }}'
+    mode: 0600
+- name: Upload systemd service file
+  ansible.builtin.template:
+    src: matrix-registration-bot.service.j2
+    dest: /etc/systemd/system/matrix-registration-bot.service
+    owner: root
+    group: root
+    mode: 0644
+- name: Enable/Restart matrix-registration-bot
+  ansible.builtin.systemd:
+    daemon_reload: yes
+    name: matrix-registration-bot.service
+    enabled: yes
+    state: restarted

--- a/contrib/ansible-role/templates/config.yml.j2
+++ b/contrib/ansible-role/templates/config.yml.j2
@@ -1,0 +1,11 @@
+bot:
+  server: "{{ matrix_client_api_endpoint }}"
+  username: "{{ matrix_registration_bot_username }}"
+  access_token: "{{ matrix_registration_bot_token }}"
+api:
+  # API endpoint of the registration tokens
+  base_url: "{{ synapse_api_endpoint }}"
+  # Access token of an administrator on the server
+  token: "{{ synapse_admin_token }}"
+logging:
+  level: INFO

--- a/contrib/ansible-role/templates/matrix-registration-bot.service.j2
+++ b/contrib/ansible-role/templates/matrix-registration-bot.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=matrix-registration-bot
+
+[Service]
+Type=simple
+WorkingDirectory=/etc/matrix-registration-bot/
+ExecStart=/opt/venvs/matrix-registration-bot/bin/python3 -m matrix_registration_bot.bot
+User={{ matrix_registration_bot_system_user }}
+Group={{ matrix_registration_bot_system_user }}
+Restart=always
+RestartSec=30
+SyslogIdentifier=matrix-reg-bot
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adds a Ansible role in a newly created `contrib` folder.
The README.md file explains the target and usage, as well as variables to define.

Note: I have not distributed Ansible roles before, please provide any relevant feedback.

