### PR TITLE
Update Dockerfile to pin in place python 3.11 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-slim AS compile-image
+FROM python:3.11-slim AS compile-image
 MAINTAINER Julian-Samuel Gebühr
 
 
@@ -13,7 +13,7 @@ COPY . .
 RUN /opt/venv/bin/pip install .
 RUN /opt/venv/bin/pip install matrix-nio==0.20.2
 
-FROM python:3-slim
+FROM python:3.11-slim
 
 RUN apt-get update && apt-get install -y libolm-dev
 COPY --from=compile-image /opt/venv /opt/venv


### PR DESCRIPTION
While installing self hosted matrix via the [ansible docker](https://github.com/spantaleev/matrix-docker-ansible-deploy) installation I faced an issue with registration bot. 
As I am running on arm architecture, so ansible is relying on building the image from source instead of pulling from docker hub, hence, pulling the new image for python:3-slim, that used to be 3.11 and now is 3.12

```
TASK [galaxy/systemd_service_manager : Fail if service isn't detected to be running] ************************************************************************************************
failed: [matrix.rocuevas.mx] (item=matrix-bot-matrix-registration-bot.service) => changed=false 
  ansible_loop_var: item
  item: matrix-bot-matrix-registration-bot.service
  msg: matrix-bot-matrix-registration-bot.service was not detected to be running. It's possible that there's a configuration problem or another service on your server interferes with it (uses the same ports, etc.). Try running `systemctl status matrix-bot-matrix-registration-bot.service` and `journalctl -fu matrix-bot-matrix-registration-bot.service` on the server to investigate. If you're on a slow or overloaded server, it may be that services take a longer time to start and that this error is a false-positive. You can consider raising the value of the `devture_systemd_service_manager_up_verification_delay_seconds` variable. See `/home/rocuevas/matrix-docker-ansible-deploy/roles/galaxy/systemd_service_manager/defaults/main.yml` for more details about that.
```
systemclt 
```
systemctl status matrix-bot-matrix-registration-bot.service
● matrix-bot-matrix-registration-bot.service - Matrix registration bot
     Loaded: loaded (/etc/systemd/system/matrix-bot-matrix-registration-bot.service; enabled; vendor preset: enabled)
     Active: activating (auto-restart) (Result: exit-code) since Fri 2023-12-15 17:53:01 UTC; 26s ago
    Process: 1643137 ExecStartPre=/usr/bin/env sh -c /usr/bin/env docker stop --time=3 matrix-bot-matrix-registration-bot 2>/dev/null || true (code=exited, status=0/>
    Process: 1643145 ExecStartPre=/usr/bin/env sh -c /usr/bin/env docker rm matrix-bot-matrix-registration-bot 2>/dev/null || true (code=exited, status=0/SUCCESS)
    Process: 1643152 ExecStart=/usr/bin/env docker run --rm --name matrix-bot-matrix-registration-bot --log-driver=none --cap-drop=ALL -e CONFIG_PATH=/config/config.>
   Main PID: 1643152 (code=exited, status=1/FAILURE)
        CPU: 59ms
```
journalctl

```
Dec 15 17:45:07 matrixsynapseubuntuminimal systemd[1]: matrix-bot-matrix-registration-bot.service: Scheduled restart job, restart counter is at 21365.
Dec 15 17:45:07 matrixsynapseubuntuminimal systemd[1]: Stopped Matrix registration bot.
Dec 15 17:45:07 matrixsynapseubuntuminimal systemd[1]: Starting Matrix registration bot...
Dec 15 17:45:07 matrixsynapseubuntuminimal systemd[1]: Started Matrix registration bot.
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]: Traceback (most recent call last):
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/bin/matrix-registration-bot", line 5, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     from matrix_registration_bot.bot import run_bot
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/lib/python3.12/site-packages/matrix_registration_bot/bot.py", line 2, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     import simplematrixbotlib as botlib
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/lib/python3.12/site-packages/simplematrixbotlib/__init__.py", line 1, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     from simplematrixbotlib.api import Api
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/lib/python3.12/site-packages/simplematrixbotlib/api.py", line 3, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     from nio import (AsyncClient, AsyncClientConfig)
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/lib/python3.12/site-packages/nio/__init__.py", line 9, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     from .client import *
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/lib/python3.12/site-packages/nio/client/__init__.py", line 3, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     from .base_client import Client, ClientConfig
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/lib/python3.12/site-packages/nio/client/base_client.py", line 36, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     from ..crypto import ENCRYPTION_ENABLED, DeviceStore, OlmDevice, OutgoingKeyRequest
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/lib/python3.12/site-packages/nio/crypto/__init__.py", line 38, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     from .olm_machine import Olm
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/lib/python3.12/site-packages/nio/crypto/olm_machine.py", line 87, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     from .sas import Sas
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/lib/python3.12/site-packages/nio/crypto/sas.py", line 26, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     from future.moves.itertools import zip_longest
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/lib/python3.12/site-packages/future/moves/__init__.py", line 5, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     from future.standard_library import import_top_level_modules
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:   File "/opt/venv/lib/python3.12/site-packages/future/standard_library/__init__.py", line 65, in <module>
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]:     import imp
Dec 15 17:45:08 matrixsynapseubuntuminimal matrix-bot-matrix-registration-bot[1637936]: ModuleNotFoundError: No module named 'imp'
Dec 15 17:45:08 matrixsynapseubuntuminimal systemd[1]: matrix-bot-matrix-registration-bot.service: Main process exited, code=exited, status=1/FAILURE
Dec 15 17:45:08 matrixsynapseubuntuminimal systemd[1]: matrix-bot-matrix-registration-bot.service: Failed with result 'exit-code'.
```

looks like this is an issue with python 3.12 dropping imp module 
, https://stackoverflow.com/questions/77274572/multiqc-modulenotfounderror-no-module-named-imp

the [3-slim python image ](https://hub.docker.com/_/python)is now using 3.12 
https://github.com/docker-library/python/blob/ab3d095cb74ee82f11b6dc59f113ad01b60d41c1/3.12/slim-bookworm/Dockerfile

so expliciting setting this to 3.11-slim should avoid this issue https://github.com/docker-library/python/blob/8bc80d1109001365559eded16423ba3692eff1ff/3.11/slim-bookworm/Dockerfile  